### PR TITLE
Santiago

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import "./globals.css";
 import { Shadows_Into_Light } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { Metadata } from "next";
 
 const shadowIntoLight = Shadows_Into_Light({
   subsets: ["latin"],
@@ -10,6 +11,26 @@ const shadowIntoLight = Shadows_Into_Light({
   variable: "--font-shadow",
 });
 
+export const metadata: Metadata = {
+  title: "🎧 Mixtape 🎶",
+
+  openGraph: {
+    title: "🎧 Mixtape 🎶",
+    description: "Crea Mixtapes para el Día del Amor y la Amistad",
+    url: "https://mixtape-eight.vercel.app/",
+    siteName: "CondorCoders",
+    images: [
+      {
+        url: "./preview.gif",
+        width: 800,
+        height: 600,
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -17,6 +38,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta charSet="utf-8" />
+        <meta
+          name="description"
+          content="Generar Mixtapes para tus relaciones interpersonales este Día de San Valentin"
+        ></meta>
+
+        <title>🎧 Mixtape 🎶</title>
+        <meta />
+      </head>
       <body
         className={`${shadowIntoLight.variable} relative min-h-dvh flex flex-col p-4`}
       >

--- a/src/app/mixtape/[id]/page.tsx
+++ b/src/app/mixtape/[id]/page.tsx
@@ -18,12 +18,9 @@ export interface MixtapeType {
   tracks: TrackType[];
 }
 
-export default async function MixtapePage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const mixtapeId = (await params).id;
+export default async function MixtapePage(props:{params: Promise<{ id:string }>}) {
+  const params = await props.params
+  const mixtapeId = params.id
   const mixtape = await getMixtape(mixtapeId);
 
   if (!mixtape) {

--- a/src/app/mixtape/[id]/page.tsx
+++ b/src/app/mixtape/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getMixtape } from "@/app/actions";
 import { Mixtape } from "@/components/mixtape";
+import PageTitle from "@/components/page-title";
 import { notFound } from "next/navigation";
 
 export interface TrackType {
@@ -34,7 +35,8 @@ export default async function MixtapePage(props:{params: Promise<{ id:string }>}
 
   return (
     <div className="w-full flex-1 overflow-hidden relative flex flex-col items-center justify-center">
-      <h1 className="text-4xl font-bold font-shadow mb-10">🎧 Mixtape 🎶</h1>
+     {/*  <h1 className="text-4xl font-bold font-shadow mb-10">🎧 Mixtape 🎶</h1> */}
+      <PageTitle className="mb-10" url="/" value="🎧 Mixtape 🎶" />
       <Mixtape {...mixtape} />
     </div>
   );

--- a/src/app/mixtape/[id]/page.tsx
+++ b/src/app/mixtape/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getMixtape } from "@/app/actions";
 import { Mixtape } from "@/components/mixtape";
+import { notFound } from "next/navigation";
 
 export interface TrackType {
   id: string;

--- a/src/app/mixtape/[id]/page.tsx
+++ b/src/app/mixtape/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { getMixtape } from "@/app/actions";
 import { Mixtape } from "@/components/mixtape";
 import PageTitle from "@/components/page-title";
-import { notFound } from "next/navigation";
 
 export interface TrackType {
   id: string;

--- a/src/app/mixtape/page.tsx
+++ b/src/app/mixtape/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+
+
+export default function HomeMixtape(){
+    redirect('/')
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import { MixtapeForm } from "@/components/mixtape-form";
+import PageTitle from "@/components/page-title";
 
 export default async function Home() {
   return (
     <main className="w-full h-full flex-1 flex flex-col">
       <div className="text-center p-4">
-        <h1 className="text-4xl font-bold font-shadow">🎧 Mixtape 🎶</h1>
+        {/* <h1 className="text-4xl font-bold font-shadow">🎧 Mixtape 🎶</h1> */}
+         <PageTitle url="/" value="🎧 Mixtape 🎶" />
         <p className="py-4 text-base">
           Turn your Spotify playlist into a mixtape and share it with someone
           who&apos;ll love it!

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from "next/link";
-import { DetailedHTMLProps, HTMLAttributes, useState } from "react";
+import { DetailedHTMLProps, HTMLAttributes } from "react";
 
 interface TitleProps
   extends DetailedHTMLProps<

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Link from "next/link";
+import { DetailedHTMLProps, HTMLAttributes, useState } from "react";
+
+interface TitleProps
+  extends DetailedHTMLProps<
+    HTMLAttributes<HTMLHeadingElement>,
+    HTMLHeadingElement
+  > {
+  className?: string;
+  value: string
+  url:string
+  
+}
+
+
+
+export default function PageTitle({value,url,className,...rest}:TitleProps){
+  
+    return (
+       <Link href={url}   >
+        <h1 className={`text-4xl font-bold font-shadow mb-10 ${className}` }
+        {...rest}>{value}</h1>
+       </Link>
+    )
+}


### PR DESCRIPTION
Añadí la redirección si el usuario no asigno un ID en Mixtape, lo regresa a la página principal. 

Agregue CEO (titulo, descripción) y un OpenGraph con un gif de ejemplo, en este caso asigne unas frases, se puede cambiar a una más acorde o rediseñar la base.

Solo agregue la redirección cuando dan clic en el logo en la página donde se visualiza el Mixtape creado.




